### PR TITLE
Add selectable keyboard layouts (EN/RU/DE)

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -32,6 +32,13 @@ enum class WritingMode : uint8_t {
   PAGINATION = 2    // Page-based display instead of scrolling
 };
 
+// --- Keyboard Layouts ---
+enum class KeyboardLayout : uint8_t {
+  QWERTY = 0,
+  RUSSIAN_JCUKEN = 1,
+  GERMAN_QWERTZ = 2
+};
+
 // --- BLE Connection State ---
 enum class BLEState : uint8_t {
   DISCONNECTED,
@@ -98,21 +105,56 @@ inline int editorFontId(FontSize size) {
 // --- HID Keycodes ---
 static constexpr uint8_t HID_KEY_A          = 0x04;
 static constexpr uint8_t HID_KEY_B          = 0x05;
+static constexpr uint8_t HID_KEY_C          = 0x06;
 static constexpr uint8_t HID_KEY_D          = 0x07;
+static constexpr uint8_t HID_KEY_E          = 0x08;
 static constexpr uint8_t HID_KEY_F          = 0x09;
+static constexpr uint8_t HID_KEY_G          = 0x0A;
+static constexpr uint8_t HID_KEY_H          = 0x0B;
+static constexpr uint8_t HID_KEY_I          = 0x0C;
+static constexpr uint8_t HID_KEY_J          = 0x0D;
+static constexpr uint8_t HID_KEY_K          = 0x0E;
+static constexpr uint8_t HID_KEY_L          = 0x0F;
+static constexpr uint8_t HID_KEY_M          = 0x10;
 static constexpr uint8_t HID_KEY_N          = 0x11;
+static constexpr uint8_t HID_KEY_O          = 0x12;
 static constexpr uint8_t HID_KEY_P          = 0x13;
 static constexpr uint8_t HID_KEY_Q          = 0x14;
 static constexpr uint8_t HID_KEY_R          = 0x15;
-static constexpr uint8_t HID_KEY_W          = 0x1A;
 static constexpr uint8_t HID_KEY_S          = 0x16;
 static constexpr uint8_t HID_KEY_T          = 0x17;
+static constexpr uint8_t HID_KEY_U          = 0x18;
+static constexpr uint8_t HID_KEY_V          = 0x19;
+static constexpr uint8_t HID_KEY_W          = 0x1A;
+static constexpr uint8_t HID_KEY_X          = 0x1B;
+static constexpr uint8_t HID_KEY_Y          = 0x1C;
 static constexpr uint8_t HID_KEY_Z          = 0x1D;
+static constexpr uint8_t HID_KEY_1          = 0x1E;
+static constexpr uint8_t HID_KEY_2          = 0x1F;
+static constexpr uint8_t HID_KEY_3          = 0x20;
+static constexpr uint8_t HID_KEY_4          = 0x21;
+static constexpr uint8_t HID_KEY_5          = 0x22;
+static constexpr uint8_t HID_KEY_6          = 0x23;
+static constexpr uint8_t HID_KEY_7          = 0x24;
+static constexpr uint8_t HID_KEY_8          = 0x25;
+static constexpr uint8_t HID_KEY_9          = 0x26;
+static constexpr uint8_t HID_KEY_0          = 0x27;
 static constexpr uint8_t HID_KEY_ENTER      = 0x28;
 static constexpr uint8_t HID_KEY_ESCAPE     = 0x29;
 static constexpr uint8_t HID_KEY_BACKSPACE  = 0x2A;
 static constexpr uint8_t HID_KEY_TAB        = 0x2B;
 static constexpr uint8_t HID_KEY_SPACE      = 0x2C;
+static constexpr uint8_t HID_KEY_MINUS      = 0x2D;
+static constexpr uint8_t HID_KEY_EQUAL      = 0x2E;
+static constexpr uint8_t HID_KEY_LEFTBRACE  = 0x2F;
+static constexpr uint8_t HID_KEY_RIGHTBRACE = 0x30;
+static constexpr uint8_t HID_KEY_BACKSLASH  = 0x31;
+static constexpr uint8_t HID_KEY_SEMICOLON  = 0x33;
+static constexpr uint8_t HID_KEY_APOSTROPHE = 0x34;
+static constexpr uint8_t HID_KEY_GRAVE      = 0x35;
+static constexpr uint8_t HID_KEY_COMMA      = 0x36;
+static constexpr uint8_t HID_KEY_DOT        = 0x37;
+static constexpr uint8_t HID_KEY_SLASH      = 0x38;
 static constexpr uint8_t HID_KEY_DELETE     = 0x4C;
 static constexpr uint8_t HID_KEY_RIGHT      = 0x4F;
 static constexpr uint8_t HID_KEY_LEFT       = 0x50;
@@ -122,6 +164,7 @@ static constexpr uint8_t HID_KEY_HOME       = 0x4A;
 static constexpr uint8_t HID_KEY_END        = 0x4D;
 static constexpr uint8_t HID_KEY_CAPSLOCK   = 0x39;
 static constexpr uint8_t HID_KEY_F2         = 0x3B;
+static constexpr uint8_t HID_KEY_NON_US_BACKSLASH = 0x64;
 
 // --- HID Modifier Masks ---
 static constexpr uint8_t MOD_CTRL_LEFT   = 0x01;
@@ -136,6 +179,12 @@ inline bool isCtrl(uint8_t mod) {
 }
 inline bool isShift(uint8_t mod) {
   return (mod & MOD_SHIFT_LEFT) || (mod & MOD_SHIFT_RIGHT);
+}
+inline bool isAltGr(uint8_t mod) {
+  const bool rightAlt = (mod & MOD_ALT_RIGHT) != 0;
+  const bool ctrlAlt = ((mod & (MOD_CTRL_LEFT | MOD_CTRL_RIGHT)) != 0)
+                    && ((mod & (MOD_ALT_LEFT | MOD_ALT_RIGHT)) != 0);
+  return rightAlt || ctrlAlt;
 }
 
 // --- Debug Logging ---

--- a/src/input_handler.cpp
+++ b/src/input_handler.cpp
@@ -3,6 +3,7 @@
 #include "file_manager.h"
 #include "ble_keyboard.h"
 #include "wifi_sync.h"
+#include "keyboard_layout.h"
 
 #include <Arduino.h>
 #include <SDCardManager.h>
@@ -15,6 +16,7 @@ extern bool deleteConfirmPending;
 extern WritingMode writingMode;
 extern FontSize fontSize;
 extern bool showWordCount;
+extern KeyboardLayout currentKeyboardLayout;
 
 // External functions
 void storePairedDevice(const std::string& address, const std::string& name);
@@ -94,49 +96,15 @@ static KeyEvent dequeueKeyEvent() {
 }
 
 char hidToAscii(uint8_t hid, uint8_t modifiers) {
-  bool shifted = isShift(modifiers) ^ capsLockOn;
-
-  // Letters a-z (HID 0x04-0x1D)
-  if (hid >= 0x04 && hid <= 0x1D) {
-    char base = 'a' + (hid - 0x04);
-    return shifted ? (base - 32) : base;
-  }
-
-  // Number row (HID 0x1E-0x27)
-  static const char unshifted[] = "1234567890";
-  static const char shiftedNum[] = "!@#$%^&*()";
-  if (hid >= 0x1E && hid <= 0x27) {
-    int idx = hid - 0x1E;
-    return isShift(modifiers) ? shiftedNum[idx] : unshifted[idx];
-  }
-
-  // Special keys
-  switch (hid) {
-    case 0x28: return '\n';  // Enter
-    case 0x2B: return '\t';  // Tab
-    case 0x2C: return ' ';   // Space
-
-    // Symbol keys
-    case 0x2D: return isShift(modifiers) ? '_' : '-';
-    case 0x2E: return isShift(modifiers) ? '+' : '=';
-    case 0x2F: return isShift(modifiers) ? '{' : '[';
-    case 0x30: return isShift(modifiers) ? '}' : ']';
-    case 0x31: return isShift(modifiers) ? '|' : '\\';
-    case 0x33: return isShift(modifiers) ? ':' : ';';
-    case 0x34: return isShift(modifiers) ? '"' : '\'';
-    case 0x35: return isShift(modifiers) ? '~' : '`';
-    case 0x36: return isShift(modifiers) ? '<' : ',';
-    case 0x37: return isShift(modifiers) ? '>' : '.';
-    case 0x38: return isShift(modifiers) ? '?' : '/';
-
-    default: return 0;
-  }
+  const char* text = keyboardLayoutQwertyText(hid, modifiers, capsLockOn);
+  if (!text || text[0] == '\0' || text[1] != '\0') return 0;
+  return text[0];
 }
 
 // Handle text editor input
 static void handleEditorKey(uint8_t keyCode, uint8_t modifiers) {
   // Ctrl shortcuts
-  if (isCtrl(modifiers)) {
+  if (isCtrl(modifiers) && !isAltGr(modifiers)) {
     if (keyCode == HID_KEY_S) {
       saveCurrentFile();
       screenDirty = true;
@@ -224,9 +192,9 @@ static void handleEditorKey(uint8_t keyCode, uint8_t modifiers) {
   }
 
   // Printable character
-  char c = hidToAscii(keyCode, modifiers);
-  if (c != 0) {
-    editorInsertChar(c);
+  const char* text = keyboardLayoutText(currentKeyboardLayout, keyCode, modifiers, capsLockOn);
+  if (text != nullptr) {
+    editorInsertText(text);
     screenDirty = true;
   }
 }
@@ -354,12 +322,12 @@ static void dispatchEvent(const KeyEvent& event) {
         FileInfo* files = getFileList();
         loadFile(files[selectedFileIndex].filename);
         screenDirty = true;
-      } else if (isCtrl(event.modifiers) && event.keyCode == HID_KEY_N) {
+      } else if (isCtrl(event.modifiers) && !isAltGr(event.modifiers) && event.keyCode == HID_KEY_N) {
         if (fc > 0) {
           FileInfo* files = getFileList();
           openTitleEdit(files[selectedFileIndex].title, UIState::FILE_BROWSER);
         }
-      } else if (isCtrl(event.modifiers) && event.keyCode == HID_KEY_D) {
+      } else if (isCtrl(event.modifiers) && !isAltGr(event.modifiers) && event.keyCode == HID_KEY_D) {
         if (fc > 0) {
           deleteConfirmPending = true;
           screenDirty = true;
@@ -380,7 +348,7 @@ static void dispatchEvent(const KeyEvent& event) {
       break;
 
     case UIState::SETTINGS: {
-      const int SETTINGS_COUNT = 6;  // Orientation, Dark Mode, Writing Mode, Font Size, Bluetooth, Paired Keyboards
+      const int SETTINGS_COUNT = 7;  // Orientation, Dark Mode, Writing Mode, Font Size, Layout, Bluetooth, Paired Keyboards
 
       // Up/Down: navigate settings list (physical buttons also map here)
       if (event.keyCode == HID_KEY_DOWN) {
@@ -404,8 +372,10 @@ static void dispatchEvent(const KeyEvent& event) {
           int v = static_cast<int>(fontSize);
           fontSize = static_cast<FontSize>((v + 1) % 3);
         } else if (settingsSelection == 4) {
-          currentState = UIState::BLUETOOTH_SETTINGS;
+          currentKeyboardLayout = keyboardLayoutNext(currentKeyboardLayout);
         } else if (settingsSelection == 5) {
+          currentState = UIState::BLUETOOTH_SETTINGS;
+        } else if (settingsSelection == 6) {
           pairedKeyboardSelection = 0;
           currentState = UIState::PAIRED_KEYBOARDS;
         }
@@ -424,6 +394,8 @@ static void dispatchEvent(const KeyEvent& event) {
         } else if (settingsSelection == 3) {
           int v = static_cast<int>(fontSize);
           fontSize = static_cast<FontSize>((v - 1 + 3) % 3);
+        } else if (settingsSelection == 4) {
+          currentKeyboardLayout = keyboardLayoutPrev(currentKeyboardLayout);
         }
         screenDirty = true;
 

--- a/src/keyboard_layout.cpp
+++ b/src/keyboard_layout.cpp
@@ -1,0 +1,234 @@
+#include "keyboard_layout.h"
+
+#include <cstddef>
+
+struct LayoutKey {
+  uint8_t hid;
+  const char* normal;
+  const char* shifted;
+  const char* altGr;
+  const char* shiftedAltGr;
+  bool capsAffected;
+};
+
+static const LayoutKey qwertyKeys[] = {
+  {HID_KEY_A, "a", "A", nullptr, nullptr, true},
+  {HID_KEY_B, "b", "B", nullptr, nullptr, true},
+  {HID_KEY_C, "c", "C", nullptr, nullptr, true},
+  {HID_KEY_D, "d", "D", nullptr, nullptr, true},
+  {HID_KEY_E, "e", "E", nullptr, nullptr, true},
+  {HID_KEY_F, "f", "F", nullptr, nullptr, true},
+  {HID_KEY_G, "g", "G", nullptr, nullptr, true},
+  {HID_KEY_H, "h", "H", nullptr, nullptr, true},
+  {HID_KEY_I, "i", "I", nullptr, nullptr, true},
+  {HID_KEY_J, "j", "J", nullptr, nullptr, true},
+  {HID_KEY_K, "k", "K", nullptr, nullptr, true},
+  {HID_KEY_L, "l", "L", nullptr, nullptr, true},
+  {HID_KEY_M, "m", "M", nullptr, nullptr, true},
+  {HID_KEY_N, "n", "N", nullptr, nullptr, true},
+  {HID_KEY_O, "o", "O", nullptr, nullptr, true},
+  {HID_KEY_P, "p", "P", nullptr, nullptr, true},
+  {HID_KEY_Q, "q", "Q", nullptr, nullptr, true},
+  {HID_KEY_R, "r", "R", nullptr, nullptr, true},
+  {HID_KEY_S, "s", "S", nullptr, nullptr, true},
+  {HID_KEY_T, "t", "T", nullptr, nullptr, true},
+  {HID_KEY_U, "u", "U", nullptr, nullptr, true},
+  {HID_KEY_V, "v", "V", nullptr, nullptr, true},
+  {HID_KEY_W, "w", "W", nullptr, nullptr, true},
+  {HID_KEY_X, "x", "X", nullptr, nullptr, true},
+  {HID_KEY_Y, "y", "Y", nullptr, nullptr, true},
+  {HID_KEY_Z, "z", "Z", nullptr, nullptr, true},
+  {HID_KEY_1, "1", "!", nullptr, nullptr, false},
+  {HID_KEY_2, "2", "@", nullptr, nullptr, false},
+  {HID_KEY_3, "3", "#", nullptr, nullptr, false},
+  {HID_KEY_4, "4", "$", nullptr, nullptr, false},
+  {HID_KEY_5, "5", "%", nullptr, nullptr, false},
+  {HID_KEY_6, "6", "^", nullptr, nullptr, false},
+  {HID_KEY_7, "7", "&", nullptr, nullptr, false},
+  {HID_KEY_8, "8", "*", nullptr, nullptr, false},
+  {HID_KEY_9, "9", "(", nullptr, nullptr, false},
+  {HID_KEY_0, "0", ")", nullptr, nullptr, false},
+  {HID_KEY_MINUS, "-", "_", nullptr, nullptr, false},
+  {HID_KEY_EQUAL, "=", "+", nullptr, nullptr, false},
+  {HID_KEY_LEFTBRACE, "[", "{", nullptr, nullptr, false},
+  {HID_KEY_RIGHTBRACE, "]", "}", nullptr, nullptr, false},
+  {HID_KEY_BACKSLASH, "\\", "|", nullptr, nullptr, false},
+  {HID_KEY_SEMICOLON, ";", ":", nullptr, nullptr, false},
+  {HID_KEY_APOSTROPHE, "'", "\"", nullptr, nullptr, false},
+  {HID_KEY_GRAVE, "`", "~", nullptr, nullptr, false},
+  {HID_KEY_COMMA, ",", "<", nullptr, nullptr, false},
+  {HID_KEY_DOT, ".", ">", nullptr, nullptr, false},
+  {HID_KEY_SLASH, "/", "?", nullptr, nullptr, false},
+  {HID_KEY_NON_US_BACKSLASH, "\\", "|", nullptr, nullptr, false},
+};
+
+static const LayoutKey russianKeys[] = {
+  {HID_KEY_Q, "й", "Й", nullptr, nullptr, true},
+  {HID_KEY_W, "ц", "Ц", nullptr, nullptr, true},
+  {HID_KEY_E, "у", "У", nullptr, nullptr, true},
+  {HID_KEY_R, "к", "К", nullptr, nullptr, true},
+  {HID_KEY_T, "е", "Е", nullptr, nullptr, true},
+  {HID_KEY_Y, "н", "Н", nullptr, nullptr, true},
+  {HID_KEY_U, "г", "Г", nullptr, nullptr, true},
+  {HID_KEY_I, "ш", "Ш", nullptr, nullptr, true},
+  {HID_KEY_O, "щ", "Щ", nullptr, nullptr, true},
+  {HID_KEY_P, "з", "З", nullptr, nullptr, true},
+  {HID_KEY_LEFTBRACE, "х", "Х", nullptr, nullptr, true},
+  {HID_KEY_RIGHTBRACE, "ъ", "Ъ", nullptr, nullptr, true},
+  {HID_KEY_A, "ф", "Ф", nullptr, nullptr, true},
+  {HID_KEY_S, "ы", "Ы", nullptr, nullptr, true},
+  {HID_KEY_D, "в", "В", nullptr, nullptr, true},
+  {HID_KEY_F, "а", "А", nullptr, nullptr, true},
+  {HID_KEY_G, "п", "П", nullptr, nullptr, true},
+  {HID_KEY_H, "р", "Р", nullptr, nullptr, true},
+  {HID_KEY_J, "о", "О", nullptr, nullptr, true},
+  {HID_KEY_K, "л", "Л", nullptr, nullptr, true},
+  {HID_KEY_L, "д", "Д", nullptr, nullptr, true},
+  {HID_KEY_SEMICOLON, "ж", "Ж", nullptr, nullptr, true},
+  {HID_KEY_APOSTROPHE, "э", "Э", nullptr, nullptr, true},
+  {HID_KEY_Z, "я", "Я", nullptr, nullptr, true},
+  {HID_KEY_X, "ч", "Ч", nullptr, nullptr, true},
+  {HID_KEY_C, "с", "С", nullptr, nullptr, true},
+  {HID_KEY_V, "м", "М", nullptr, nullptr, true},
+  {HID_KEY_B, "и", "И", nullptr, nullptr, true},
+  {HID_KEY_N, "т", "Т", nullptr, nullptr, true},
+  {HID_KEY_M, "ь", "Ь", nullptr, nullptr, true},
+  {HID_KEY_COMMA, "б", "Б", nullptr, nullptr, true},
+  {HID_KEY_DOT, "ю", "Ю", nullptr, nullptr, true},
+  {HID_KEY_GRAVE, "ё", "Ё", nullptr, nullptr, true},
+  {HID_KEY_1, "1", "!", nullptr, nullptr, false},
+  {HID_KEY_2, "2", "\"", nullptr, nullptr, false},
+  {HID_KEY_3, "3", "№", nullptr, nullptr, false},
+  {HID_KEY_4, "4", ";", nullptr, nullptr, false},
+  {HID_KEY_5, "5", "%", nullptr, nullptr, false},
+  {HID_KEY_6, "6", ":", nullptr, nullptr, false},
+  {HID_KEY_7, "7", "?", nullptr, nullptr, false},
+  {HID_KEY_8, "8", "*", nullptr, nullptr, false},
+  {HID_KEY_9, "9", "(", nullptr, nullptr, false},
+  {HID_KEY_0, "0", ")", nullptr, nullptr, false},
+  {HID_KEY_MINUS, "-", "_", nullptr, nullptr, false},
+  {HID_KEY_EQUAL, "=", "+", nullptr, nullptr, false},
+  {HID_KEY_BACKSLASH, "\\", "/", nullptr, nullptr, false},
+  {HID_KEY_SLASH, ".", ",", nullptr, nullptr, false},
+  {HID_KEY_NON_US_BACKSLASH, "\\", "/", nullptr, nullptr, false},
+};
+
+static const LayoutKey germanKeys[] = {
+  {HID_KEY_A, "a", "A", nullptr, nullptr, true},
+  {HID_KEY_B, "b", "B", nullptr, nullptr, true},
+  {HID_KEY_C, "c", "C", nullptr, nullptr, true},
+  {HID_KEY_D, "d", "D", nullptr, nullptr, true},
+  {HID_KEY_E, "e", "E", "€", nullptr, true},
+  {HID_KEY_F, "f", "F", nullptr, nullptr, true},
+  {HID_KEY_G, "g", "G", nullptr, nullptr, true},
+  {HID_KEY_H, "h", "H", nullptr, nullptr, true},
+  {HID_KEY_I, "i", "I", nullptr, nullptr, true},
+  {HID_KEY_J, "j", "J", nullptr, nullptr, true},
+  {HID_KEY_K, "k", "K", nullptr, nullptr, true},
+  {HID_KEY_L, "l", "L", nullptr, nullptr, true},
+  {HID_KEY_M, "m", "M", "µ", nullptr, true},
+  {HID_KEY_N, "n", "N", nullptr, nullptr, true},
+  {HID_KEY_O, "o", "O", nullptr, nullptr, true},
+  {HID_KEY_P, "p", "P", nullptr, nullptr, true},
+  {HID_KEY_Q, "q", "Q", "@", nullptr, true},
+  {HID_KEY_R, "r", "R", nullptr, nullptr, true},
+  {HID_KEY_S, "s", "S", nullptr, nullptr, true},
+  {HID_KEY_T, "t", "T", nullptr, nullptr, true},
+  {HID_KEY_U, "u", "U", nullptr, nullptr, true},
+  {HID_KEY_V, "v", "V", nullptr, nullptr, true},
+  {HID_KEY_W, "w", "W", nullptr, nullptr, true},
+  {HID_KEY_X, "x", "X", nullptr, nullptr, true},
+  {HID_KEY_Y, "z", "Z", nullptr, nullptr, true},
+  {HID_KEY_Z, "y", "Y", nullptr, nullptr, true},
+  {HID_KEY_1, "1", "!", nullptr, nullptr, false},
+  {HID_KEY_2, "2", "\"", "²", nullptr, false},
+  {HID_KEY_3, "3", "§", "³", nullptr, false},
+  {HID_KEY_4, "4", "$", nullptr, nullptr, false},
+  {HID_KEY_5, "5", "%", nullptr, nullptr, false},
+  {HID_KEY_6, "6", "&", nullptr, nullptr, false},
+  {HID_KEY_7, "7", "/", "{", nullptr, false},
+  {HID_KEY_8, "8", "(", "[", nullptr, false},
+  {HID_KEY_9, "9", ")", "]", nullptr, false},
+  {HID_KEY_0, "0", "=", "}", nullptr, false},
+  {HID_KEY_MINUS, "ß", "?", "\\", nullptr, false},
+  {HID_KEY_EQUAL, "´", "`", "~", nullptr, false},
+  {HID_KEY_LEFTBRACE, "ü", "Ü", nullptr, nullptr, true},
+  {HID_KEY_RIGHTBRACE, "+", "*", "~", nullptr, false},
+  {HID_KEY_BACKSLASH, "#", "'", nullptr, nullptr, false},
+  {HID_KEY_SEMICOLON, "ö", "Ö", nullptr, nullptr, true},
+  {HID_KEY_APOSTROPHE, "ä", "Ä", nullptr, nullptr, true},
+  {HID_KEY_GRAVE, "^", "°", nullptr, nullptr, false},
+  {HID_KEY_COMMA, ",", ";", nullptr, nullptr, false},
+  {HID_KEY_DOT, ".", ":", nullptr, nullptr, false},
+  {HID_KEY_SLASH, "-", "_", nullptr, nullptr, false},
+  {HID_KEY_NON_US_BACKSLASH, "<", ">", "|", nullptr, false},
+};
+
+template <size_t N>
+static const char* lookupKey(const LayoutKey (&keys)[N], uint8_t hid, uint8_t modifiers, bool capsLockOn) {
+  if (hid == HID_KEY_ENTER) return "\n";
+  if (hid == HID_KEY_TAB) return "\t";
+  if (hid == HID_KEY_SPACE) return " ";
+
+  const bool shifted = isShift(modifiers);
+  const bool altGr = isAltGr(modifiers);
+  for (const LayoutKey& key : keys) {
+    if (key.hid != hid) continue;
+
+    if (altGr && key.altGr) {
+      return (shifted && key.shiftedAltGr) ? key.shiftedAltGr : key.altGr;
+    }
+
+    const bool useShifted = key.capsAffected ? (shifted ^ capsLockOn) : shifted;
+    return useShifted ? key.shifted : key.normal;
+  }
+
+  return nullptr;
+}
+
+KeyboardLayout keyboardLayoutFromIndex(int index) {
+  if (index < 0 || index >= KEYBOARD_LAYOUT_COUNT) return KeyboardLayout::QWERTY;
+  return static_cast<KeyboardLayout>(index);
+}
+
+KeyboardLayout keyboardLayoutNext(KeyboardLayout layout) {
+  return keyboardLayoutFromIndex((static_cast<int>(layout) + 1) % KEYBOARD_LAYOUT_COUNT);
+}
+
+KeyboardLayout keyboardLayoutPrev(KeyboardLayout layout) {
+  return keyboardLayoutFromIndex((static_cast<int>(layout) - 1 + KEYBOARD_LAYOUT_COUNT) % KEYBOARD_LAYOUT_COUNT);
+}
+
+const char* keyboardLayoutName(KeyboardLayout layout) {
+  switch (layout) {
+    case KeyboardLayout::RUSSIAN_JCUKEN: return "RU ЙЦУКЕН";
+    case KeyboardLayout::GERMAN_QWERTZ:  return "DE QWERTZ";
+    case KeyboardLayout::QWERTY:
+    default:                             return "US QWERTY";
+  }
+}
+
+const char* keyboardLayoutShortName(KeyboardLayout layout) {
+  switch (layout) {
+    case KeyboardLayout::RUSSIAN_JCUKEN: return "RU";
+    case KeyboardLayout::GERMAN_QWERTZ:  return "DE";
+    case KeyboardLayout::QWERTY:
+    default:                             return "US";
+  }
+}
+
+const char* keyboardLayoutQwertyText(uint8_t hid, uint8_t modifiers, bool capsLockOn) {
+  return lookupKey(qwertyKeys, hid, modifiers, capsLockOn);
+}
+
+const char* keyboardLayoutText(KeyboardLayout layout, uint8_t hid, uint8_t modifiers, bool capsLockOn) {
+  switch (layout) {
+    case KeyboardLayout::RUSSIAN_JCUKEN:
+      return lookupKey(russianKeys, hid, modifiers, capsLockOn);
+    case KeyboardLayout::GERMAN_QWERTZ:
+      return lookupKey(germanKeys, hid, modifiers, capsLockOn);
+    case KeyboardLayout::QWERTY:
+    default:
+      return keyboardLayoutQwertyText(hid, modifiers, capsLockOn);
+  }
+}

--- a/src/keyboard_layout.h
+++ b/src/keyboard_layout.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "config.h"
+
+static constexpr int KEYBOARD_LAYOUT_COUNT = 3;
+
+KeyboardLayout keyboardLayoutFromIndex(int index);
+KeyboardLayout keyboardLayoutNext(KeyboardLayout layout);
+KeyboardLayout keyboardLayoutPrev(KeyboardLayout layout);
+const char* keyboardLayoutName(KeyboardLayout layout);
+const char* keyboardLayoutShortName(KeyboardLayout layout);
+
+// Returns a UTF-8 string literal for printable keys, or nullptr for non-printable keys.
+const char* keyboardLayoutText(KeyboardLayout layout, uint8_t hid, uint8_t modifiers, bool capsLockOn);
+
+// US QWERTY is used in fields where ASCII input is expected, regardless of editor layout.
+const char* keyboardLayoutQwertyText(uint8_t hid, uint8_t modifiers, bool capsLockOn);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include "file_manager.h"
 #include "ui_renderer.h"
 #include "wifi_sync.h"
+#include "keyboard_layout.h"
 
 // Enum for sleep reasons
 enum class SleepReason {
@@ -61,6 +62,7 @@ bool deleteConfirmPending = false;
 WritingMode writingMode = WritingMode::NORMAL;
 FontSize fontSize = FontSize::LARGE;
 bool showWordCount = true;
+KeyboardLayout currentKeyboardLayout = KeyboardLayout::QWERTY;
 
 // --- OTA App Detection ---
 OtaAppEntry otaApps[MAX_OTA_APPS];
@@ -196,6 +198,7 @@ void setup() {
   writingMode = static_cast<WritingMode>(uiPrefs.getUChar("writeMode", 0));
   fontSize = static_cast<FontSize>(uiPrefs.getUChar("fontSize", 2));
   showWordCount = uiPrefs.getBool("showWC", true);
+  currentKeyboardLayout = keyboardLayoutFromIndex(uiPrefs.getUChar("layout", 0));
 
   // Apply saved orientation
   {
@@ -222,11 +225,13 @@ void setup() {
       int wm = jsonGetInt(uiBuf, "writeMode");
       int fs = jsonGetInt(uiBuf, "fontSize");
       int wc = jsonGetInt(uiBuf, "showWC");
+      int kl = jsonGetInt(uiBuf, "layout");
       if (o  >= 0) { uiPrefs.putUChar("orient",    (uint8_t)o);  currentOrientation = static_cast<Orientation>(o); }
       if (d  >= 0) { uiPrefs.putBool("darkMode",   d != 0);      darkMode           = (d != 0); }
       if (wm >= 0) { uiPrefs.putUChar("writeMode", (uint8_t)wm); writingMode        = static_cast<WritingMode>(wm); }
       if (fs >= 0) { uiPrefs.putUChar("fontSize",  (uint8_t)fs); fontSize           = static_cast<FontSize>(fs); }
       if (wc >= 0) { uiPrefs.putBool("showWC",     wc != 0);     showWordCount      = (wc != 0); }
+      if (kl >= 0) { uiPrefs.putUChar("layout",    (uint8_t)kl); currentKeyboardLayout = keyboardLayoutFromIndex(kl); }
       // Re-apply orientation in case it changed
       GfxRenderer::Orientation gfxOrient = GfxRenderer::Portrait;
       switch (currentOrientation) {
@@ -688,25 +693,30 @@ void loop() {
   static WritingMode lastSavedWritingMode = writingMode;
   static FontSize lastSavedFontSize = fontSize;
   static bool lastSavedShowWordCount = showWordCount;
+  static KeyboardLayout lastSavedKeyboardLayout = currentKeyboardLayout;
   if (currentOrientation != lastSavedOrientation || darkMode != lastSavedDarkMode
       || writingMode != lastSavedWritingMode || fontSize != lastSavedFontSize
-      || showWordCount != lastSavedShowWordCount) {
+      || showWordCount != lastSavedShowWordCount
+      || currentKeyboardLayout != lastSavedKeyboardLayout) {
     uiPrefs.putUChar("orient", static_cast<uint8_t>(currentOrientation));
     uiPrefs.putBool("darkMode", darkMode);
     uiPrefs.putUChar("writeMode", static_cast<uint8_t>(writingMode));
     uiPrefs.putUChar("fontSize", static_cast<uint8_t>(fontSize));
     uiPrefs.putBool("showWC", showWordCount);
+    uiPrefs.putUChar("layout", static_cast<uint8_t>(currentKeyboardLayout));
     lastSavedOrientation = currentOrientation;
     lastSavedDarkMode = darkMode;
     lastSavedWritingMode = writingMode;
     lastSavedFontSize = fontSize;
     lastSavedShowWordCount = showWordCount;
+    lastSavedKeyboardLayout = currentKeyboardLayout;
     // Keep SD backup in sync so settings survive a firmware flash
-    static char uiBuf[128];
+    static char uiBuf[160];
     snprintf(uiBuf, sizeof(uiBuf),
-             "{\"orient\":%d,\"dark\":%d,\"writeMode\":%d,\"fontSize\":%d,\"showWC\":%d}",
+             "{\"orient\":%d,\"dark\":%d,\"writeMode\":%d,\"fontSize\":%d,\"showWC\":%d,\"layout\":%d}",
              (int)currentOrientation, darkMode ? 1 : 0,
-             (int)writingMode, (int)fontSize, showWordCount ? 1 : 0);
+             (int)writingMode, (int)fontSize, showWordCount ? 1 : 0,
+             (int)currentKeyboardLayout);
     if (!SdMan.exists("/microslate")) SdMan.mkdir("/microslate");
     sdWriteFile("/microslate/ui_prefs.json", uiBuf);
   }

--- a/src/text_editor.cpp
+++ b/src/text_editor.cpp
@@ -25,6 +25,77 @@ static bool lineBreaksDirty = true;  // Only recompute line breaks when buffer/c
 // Forward declaration
 static void ensureCursorVisible(int visibleLines);
 
+static bool isUtf8ContinuationByte(unsigned char c) {
+  return (c & 0xC0) == 0x80;
+}
+
+static int utf8CharLenAt(int pos) {
+  if (pos < 0 || pos >= (int)textLength) return 0;
+  unsigned char c = static_cast<unsigned char>(textBuffer[pos]);
+  int len = 1;
+  if (c < 0x80) len = 1;
+  else if ((c >> 5) == 0x6) len = 2;
+  else if ((c >> 4) == 0xE) len = 3;
+  else if ((c >> 3) == 0x1E) len = 4;
+  if (pos + len > (int)textLength) return 1;
+  return len;
+}
+
+static int utf8NextPos(int pos) {
+  if (pos >= (int)textLength) return (int)textLength;
+  int next = pos + utf8CharLenAt(pos);
+  return std::min(next, (int)textLength);
+}
+
+static int utf8PrevPos(int pos) {
+  if (pos <= 0) return 0;
+  pos--;
+  while (pos > 0 && isUtf8ContinuationByte(static_cast<unsigned char>(textBuffer[pos]))) {
+    pos--;
+  }
+  return pos;
+}
+
+static int utf8CountChars(int start, int end) {
+  start = std::max(0, start);
+  end = std::min(end, (int)textLength);
+  int count = 0;
+  for (int i = start; i < end; i = utf8NextPos(i)) {
+    count++;
+  }
+  return count;
+}
+
+static int lineContentEnd(int lineIndex) {
+  int lineStart = linePositions[lineIndex];
+  int lineEnd = (lineIndex + 1 < lineCount) ? linePositions[lineIndex + 1] : (int)textLength;
+  if (lineEnd > lineStart && textBuffer[lineEnd - 1] == '\n') lineEnd--;
+  return lineEnd;
+}
+
+static int byteOffsetForColumn(int lineStart, int lineEnd, int col) {
+  int pos = lineStart;
+  for (int i = 0; i < col && pos < lineEnd; i++) {
+    pos = utf8NextPos(pos);
+  }
+  return std::min(pos, lineEnd);
+}
+
+static void deleteByteRange(int start, int end) {
+  if (start < 0 || end <= start || start >= (int)textLength) return;
+  end = std::min(end, (int)textLength);
+
+  memmove(textBuffer + start, textBuffer + end, textLength - end);
+  textLength -= (end - start);
+  cursorPosition = start;
+  textBuffer[textLength] = '\0';
+  unsavedChanges = true;
+  lineBreaksDirty = true;
+
+  editorRecalculateLines();
+  ensureCursorVisible(storedVisibleLines);
+}
+
 // Recalculate line breaks (word wrap) and cursor position.
 // The O(textLength) line break loop only runs when the buffer or charsPerLine changed.
 // Cursor line/col is always recomputed (cheap O(cursorLine) with early exit).
@@ -37,7 +108,7 @@ void editorRecalculateLines() {
     int col = 0;
     int lastSpace = -1;
 
-    for (int i = 0; i < (int)textLength && lineCount < MAX_LINES; i++) {
+    for (int i = 0; i < (int)textLength && lineCount < MAX_LINES;) {
       if (textBuffer[i] == '\n') {
         // Hard line break
         if (lineCount < MAX_LINES) {
@@ -46,9 +117,11 @@ void editorRecalculateLines() {
         }
         col = 0;
         lastSpace = -1;
+        i++;
         continue;
       }
 
+      int charEnd = utf8NextPos(i);
       if (textBuffer[i] == ' ') {
         lastSpace = i;
       }
@@ -60,16 +133,18 @@ void editorRecalculateLines() {
         if (lastSpace > linePositions[lineCount - 1]) {
           breakPos = lastSpace + 1; // Break after space
         } else {
-          breakPos = i + 1;  // Hard break mid-word
+          breakPos = charEnd;  // Hard break mid-word, but never inside UTF-8
         }
 
         if (lineCount < MAX_LINES) {
           linePositions[lineCount] = breakPos;
           lineCount++;
         }
-        col = i + 1 - breakPos;
+        col = utf8CountChars(breakPos, charEnd);
         lastSpace = -1;
       }
+
+      i = charEnd;
     }
     lineBreaksDirty = false;
   }
@@ -83,7 +158,7 @@ void editorRecalculateLines() {
       break;
     }
   }
-  cursorCol = cursorPosition - linePositions[cursorLine];
+  cursorCol = utf8CountChars(linePositions[cursorLine], cursorPosition);
 }
 
 // Ensure cursor is visible by adjusting viewport
@@ -152,15 +227,22 @@ int editorGetWordCount() {
 }
 
 void editorInsertChar(char c) {
-  if (textLength >= TEXT_BUFFER_SIZE - 1) return;
+  char text[2] = {c, '\0'};
+  editorInsertText(text);
+}
+
+void editorInsertText(const char* text) {
+  if (!text || text[0] == '\0') return;
+  size_t insertLen = strlen(text);
+  if (textLength + insertLen >= TEXT_BUFFER_SIZE) return;
 
   // Shift text right
-  for (int i = (int)textLength; i > cursorPosition; i--) {
-    textBuffer[i] = textBuffer[i - 1];
-  }
-  textBuffer[cursorPosition] = c;
-  cursorPosition++;
-  textLength++;
+  memmove(textBuffer + cursorPosition + insertLen,
+          textBuffer + cursorPosition,
+          textLength - cursorPosition);
+  memcpy(textBuffer + cursorPosition, text, insertLen);
+  cursorPosition += insertLen;
+  textLength += insertLen;
   textBuffer[textLength] = '\0';
   unsavedChanges = true;
   lineBreaksDirty = true;
@@ -172,37 +254,20 @@ void editorInsertChar(char c) {
 void editorDeleteChar() {
   if (cursorPosition <= 0 || textLength == 0) return;
 
-  for (int i = cursorPosition - 1; i < (int)textLength - 1; i++) {
-    textBuffer[i] = textBuffer[i + 1];
-  }
-  cursorPosition--;
-  textLength--;
-  textBuffer[textLength] = '\0';
-  unsavedChanges = true;
-  lineBreaksDirty = true;
-
-  editorRecalculateLines();
-  ensureCursorVisible(storedVisibleLines);
+  int start = utf8PrevPos(cursorPosition);
+  deleteByteRange(start, cursorPosition);
 }
 
 void editorDeleteForward() {
   if (cursorPosition >= (int)textLength) return;
 
-  for (int i = cursorPosition; i < (int)textLength - 1; i++) {
-    textBuffer[i] = textBuffer[i + 1];
-  }
-  textLength--;
-  textBuffer[textLength] = '\0';
-  unsavedChanges = true;
-  lineBreaksDirty = true;
-
-  editorRecalculateLines();
-  ensureCursorVisible(storedVisibleLines);
+  int end = utf8NextPos(cursorPosition);
+  deleteByteRange(cursorPosition, end);
 }
 
 void editorMoveCursorLeft() {
   if (cursorPosition > 0) {
-    cursorPosition--;
+    cursorPosition = utf8PrevPos(cursorPosition);
     editorRecalculateLines();
     ensureCursorVisible(storedVisibleLines);
   }
@@ -210,7 +275,7 @@ void editorMoveCursorLeft() {
 
 void editorMoveCursorRight() {
   if (cursorPosition < (int)textLength) {
-    cursorPosition++;
+    cursorPosition = utf8NextPos(cursorPosition);
     editorRecalculateLines();
     ensureCursorVisible(storedVisibleLines);
   }
@@ -222,12 +287,9 @@ void editorMoveCursorUp() {
 
   int targetLine = cursorLine - 1;
   int lineStart = linePositions[targetLine];
-  int lineEnd = (targetLine + 1 < lineCount) ? linePositions[targetLine + 1] : (int)textLength;
-  int lineLen = lineEnd - lineStart;
-  // Don't count trailing newline
-  if (lineLen > 0 && textBuffer[lineStart + lineLen - 1] == '\n') lineLen--;
+  int lineEnd = lineContentEnd(targetLine);
 
-  cursorPosition = lineStart + std::min(cursorCol, lineLen);
+  cursorPosition = byteOffsetForColumn(lineStart, lineEnd, cursorCol);
   editorRecalculateLines();
   ensureCursorVisible(storedVisibleLines);
 }
@@ -237,11 +299,9 @@ void editorMoveCursorDown() {
 
   int targetLine = cursorLine + 1;
   int lineStart = linePositions[targetLine];
-  int lineEnd = (targetLine + 1 < lineCount) ? linePositions[targetLine + 1] : (int)textLength;
-  int lineLen = lineEnd - lineStart;
-  if (lineLen > 0 && textBuffer[lineStart + lineLen - 1] == '\n') lineLen--;
+  int lineEnd = lineContentEnd(targetLine);
 
-  cursorPosition = lineStart + std::min(cursorCol, lineLen);
+  cursorPosition = byteOffsetForColumn(lineStart, lineEnd, cursorCol);
   editorRecalculateLines();
   ensureCursorVisible(storedVisibleLines);
 }

--- a/src/text_editor.h
+++ b/src/text_editor.h
@@ -13,6 +13,7 @@ int editorGetCursorPosition();
 
 // Editing operations
 void editorInsertChar(char c);
+void editorInsertText(const char* text);
 void editorDeleteChar();     // Backspace
 void editorDeleteForward();  // Delete key
 

--- a/src/ui_renderer.cpp
+++ b/src/ui_renderer.cpp
@@ -4,6 +4,7 @@
 #include "file_manager.h"
 #include "ble_keyboard.h"
 #include "wifi_sync.h"
+#include "keyboard_layout.h"
 
 #include <GfxRenderer.h>
 #include <HalGPIO.h>
@@ -19,6 +20,7 @@ extern bool deleteConfirmPending;
 extern WritingMode writingMode;
 extern FontSize fontSize;
 extern bool showWordCount;
+extern KeyboardLayout currentKeyboardLayout;
 
 // External functions
 uint32_t getCurrentPasskey();
@@ -271,7 +273,7 @@ static void drawEditorLine(GfxRenderer& renderer, int lineIdx, int x, int yPos,
 
   int len = dispEnd - lineStart;
   if (len > 0) {
-    char lineBuf[256];
+    char lineBuf[512];
     int copyLen = (len < (int)sizeof(lineBuf) - 1) ? len : (int)sizeof(lineBuf) - 1;
     strncpy(lineBuf, buf + lineStart, copyLen);
     lineBuf[copyLen] = '\0';
@@ -283,12 +285,17 @@ static void drawEditorLine(GfxRenderer& renderer, int lineIdx, int x, int yPos,
 static void drawEditorCursor(GfxRenderer& renderer, int cursorY, int lineHeight,
                              int sw, bool tc) {
   int curLine = editorGetCursorLine();
-  int curCol = editorGetCursorCol();
+  int curPos = editorGetCursorPosition();
   char* buf = editorGetBuffer();
 
   int lineStart = editorGetLinePosition(curLine);
-  char prefix[256];
-  int prefixLen = (curCol < (int)sizeof(prefix) - 1) ? curCol : (int)sizeof(prefix) - 1;
+  char prefix[512];
+  int prefixLen = curPos - lineStart;
+  if (prefixLen < 0) prefixLen = 0;
+  if (prefixLen > (int)sizeof(prefix) - 1) prefixLen = (int)sizeof(prefix) - 1;
+  while (prefixLen > 0 && ((static_cast<unsigned char>(buf[lineStart + prefixLen]) & 0xC0) == 0x80)) {
+    prefixLen--;
+  }
   strncpy(prefix, buf + lineStart, prefixLen);
   prefix[prefixLen] = '\0';
 
@@ -447,8 +454,6 @@ void drawTextEditor(GfxRenderer& renderer, HalGPIO& gpio) {
   editorSetVisibleLines(visibleLines);
 
   int vpStart = editorGetViewportStart();
-  char* buf = editorGetBuffer();
-  size_t bufLen = editorGetLength();
 
   // Draw visible lines
   for (int i = 0; i < visibleLines && (vpStart + i) < totalLines; i++) {
@@ -488,6 +493,9 @@ void drawRenameScreen(GfxRenderer& renderer, HalGPIO& gpio) {
   if (cursorX + 2 < sw - 15)
     renderer.fillRect(cursorX, textY, 2, 16, tc);
 
+  drawClippedText(renderer, FONT_SMALL, 20, boxY + boxH + 8,
+                  "File title input uses US QWERTY", sw - 40, tc);
+
   // Footer
   clippedLine(renderer, 5, sh - 36, sw - 5, sh - 36, tc);
   drawClippedText(renderer, FONT_SMALL, 10, sh - 30, "Enter: Confirm   Esc: Cancel", 0, tc);
@@ -506,11 +514,11 @@ void drawSettingsMenu(GfxRenderer& renderer, HalGPIO& gpio) {
   drawBattery(renderer, gpio);
   clippedLine(renderer, 5, 32, sw - 5, 32, !darkMode);
 
-  // Setting items: Orientation, Dark Mode, Writing Mode, Font Size, Bluetooth, Paired Keyboards
+  // Setting items: Orientation, Dark Mode, Writing Mode, Font Size, Layout, Bluetooth, Paired Keyboards
   static const char* labels[] = {
-    "Orientation", "Dark Mode", "Writing Mode", "Font Size", "Bluetooth", "Paired Keyboards"
+    "Orientation", "Dark Mode", "Writing Mode", "Font Size", "Keyboard Layout", "Bluetooth", "Paired Keyboards"
   };
-  const int SETTINGS_COUNT = 6;
+  const int SETTINGS_COUNT = 7;
 
   // Compute line height to fit all items — use smaller spacing if needed
   int lineH = 38;
@@ -554,7 +562,10 @@ void drawSettingsMenu(GfxRenderer& renderer, HalGPIO& gpio) {
         case FontSize::MEDIUM: strcpy(val, "Medium"); break;
         default:               strcpy(val, "Large"); break;
       }
-    } else if (i == 5) {
+    } else if (i == 4) {
+      strncpy(val, keyboardLayoutName(currentKeyboardLayout), sizeof(val) - 1);
+      val[sizeof(val) - 1] = '\0';
+    } else if (i == 6) {
       int kbCount = getPairedKeyboardCount();
       if (kbCount == 0) strcpy(val, "None");
       else if (kbCount == 1) strcpy(val, "1 keyboard");
@@ -873,7 +884,8 @@ void drawSyncScreen(GfxRenderer& renderer, HalGPIO& gpio) {
       if (cursorX + cursorW < sw)
         renderer.fillRect(cursorX, 66, cursorW, 20, tc);
 
-      drawClippedText(renderer, FONT_SMALL, 20, 110, "Enter: Connect   Esc: Cancel", 0, tc);
+      drawClippedText(renderer, FONT_SMALL, 20, 104, "Password input uses US QWERTY", sw - 40, tc);
+      drawClippedText(renderer, FONT_SMALL, 20, 122, "Enter: Connect   Esc: Cancel", 0, tc);
       break;
     }
 
@@ -978,4 +990,3 @@ void drawSyncScreen(GfxRenderer& renderer, HalGPIO& gpio) {
 
   renderer.beginRefresh(HalDisplay::FAST_REFRESH);
 }
-

--- a/src/wifi_sync.cpp
+++ b/src/wifi_sync.cpp
@@ -610,7 +610,7 @@ void syncHandleKey(uint8_t keyCode, uint8_t modifiers) {
           screenDirty = true;
         }
       } else {
-        // Printable character — reuse hidToAscii from input_handler
+        // Printable character — Wi-Fi passwords always use US QWERTY input.
         extern char hidToAscii(uint8_t hid, uint8_t modifiers);
         char c = hidToAscii(keyCode, modifiers);
         if (c != 0 && c >= ' ' && c != '\n' && c != '\t' && passwordLen < MAX_PASSWORD_LEN) {


### PR DESCRIPTION
Hello. Thank you for this awesome project! The idea is brilliant!

My main language is Russian, so I found myself in the same situation as in the issues #11 and #12.

Since I just wanted to have fun rather than seriosly participate in the development on project, I've used Codex to implement layout switching.

I don't expect this version to be included in the main branch, as it's vibe-coded with a single prompt and I didn't even read the code. I just wanted to test the project with this necessary feature for non-English writers.

Since there has been no activity on related issues, I've decided to create this PR to allow people like me to use this vibe-coded version, which has layout switching functionality.

Maybe you'll want to include this version into your browser installer to make it easier for people to install it (especially with CrossPoint dualbooting).