### PR TITLE
Fix reboot when pairing a new keyboard (SD/display SPI bus contention)

### DIFF
--- a/src/ble_keyboard.cpp
+++ b/src/ble_keyboard.cpp
@@ -525,6 +525,10 @@ static void nvs_clearSlot(int idx) {
 
 static constexpr char BLE_BACKUP_PATH[] = "/microslate/ble_kb.json";
 
+// Set from the ble_conn task when a new keyboard is stored; consumed by bleLoop()
+// on the main task, which owns all SPI (display + SD) access.
+static volatile bool bleBackupPending = false;
+
 static void writeBleBackup() {
     static char buf[512];
     int count = nvs_loadCount();
@@ -643,6 +647,14 @@ void bleSetup() {
 }
 
 void bleLoop() {
+  // Flush a deferred SD backup requested by the ble_conn task (first-time pairing).
+  // Runs here on the main task so it can never overlap an e-ink refresh on the
+  // shared SPI bus. Wait until the connect task has fully exited.
+  if (bleBackupPending && connectTaskHandle == nullptr) {
+    bleBackupPending = false;
+    writeBleBackup();
+  }
+
   // Detect when a one-shot scan finishes
   if (isScanning && !NimBLEDevice::getScan()->isScanning()) {
     isScanning = false;
@@ -880,7 +892,11 @@ void storePairedDevice(const std::string& address, const std::string& name) {
   prefs.putUChar("last_kb", (uint8_t)idx);
   DBG_PRINTF("[BLE] Stored new paired keyboard slot %d: %s (%s)\n",
              idx, name.c_str(), address.c_str());
-  writeBleBackup();
+  // Do NOT write the SD backup here: this function runs inside the ble_conn task
+  // during a first-time pairing, while the main task may be mid e-ink refresh.
+  // The SD card and display share the SPI bus, and concurrent access from two
+  // tasks corrupts the bus and crashes the device. Defer to bleLoop() (main task).
+  bleBackupPending = true;
 }
 
 bool getStoredDevice(std::string& address, std::string& name) {


### PR DESCRIPTION
## Problem

Pairing a **new** BLE keyboard reboots the device the moment the connection completes. Already-paired keyboards reconnect fine, so this only shows up the first time a given keyboard is stored (reproduced with a Doohoeek dual-device keyboard; Logitech/Keychron reconnects were unaffected).

## Root cause

`storePairedDevice()` runs inside the `ble_conn` FreeRTOS task. On a first-time pairing it reaches the `writeBleBackup()` call, which writes the backup JSON to the SD card — from the BLE task. At that same moment the main task is typically mid e-ink refresh (redrawing the Bluetooth screen after the status change, ~430 ms).

The SD card and the display share the SPI bus (`SPI_MISO 7`, see `lib/hal/HalGPIO.h`), so the two tasks interleave transfers on the same bus → bus corruption → crash → reboot.

The update path for already-stored keyboards returns before `writeBleBackup()`, which is why only first-time pairings crashed.

## Fix

`storePairedDevice()` now only sets a `bleBackupPending` flag. `bleLoop()` — which runs on the main task, the sole owner of SPI — flushes the backup once the connect task has fully exited. No behaviour change otherwise; the backup is written within one loop iteration of the pairing.

## Testing

- Built with PlatformIO (`pio run`), no new warnings.
- On hardware (Xteink X4): pairing the Doohoeek keyboard reliably rebooted the device before this change; after it, pairing completes and the SD backup file is written correctly. Existing keyboards still reconnect, forget/switch flows unaffected.

